### PR TITLE
fix: 接收频道消息表态后无法响应消息

### DIFF
--- a/src/event/notice.ts
+++ b/src/event/notice.ts
@@ -500,7 +500,7 @@ export class MessageReactionNoticeEvent extends NoticeEvent{
         this.guild_id = payload.guild_id
         this.channel_id = payload.channel_id
         this.user_id = payload.user_id
-        if(payload.target.type!==ReactionTargetType.Message) throw new Error(`unsupported reaction target type: ${payload.target.type}`)
+        if(![ReactionTargetType.Message, ReactionTargetType.ReactionTargetType_MSG].includes(payload.target.type)) throw new Error(`unsupported reaction target type: ${payload.target.type}`)
         this.message_id = payload.target.id
         this.emoji = payload.emoji
     }

--- a/src/qqBot.ts
+++ b/src/qqBot.ts
@@ -87,9 +87,14 @@ export class QQBot extends EventEmitter {
         const event_id = wsRes.id || '';
         if (!payload || !event) return;
         const transformEvent = QQEvent[event] || 'system'
-        const result=this.processPayload(event_id,transformEvent,payload)
-        if(!result) return this.logger.debug('解析事件失败',wsRes)
-        this.em(transformEvent, result);
+
+        try {
+            const result=this.processPayload(event_id,transformEvent,payload)
+            if(!result) return this.logger.debug('解析事件失败',wsRes)
+            this.em(transformEvent, result);
+        } catch (error) {
+            return this.logger.debug('解析事件失败',wsRes)
+        }
     }
     /**
      * 上传多媒体文件

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,7 @@ export enum ReactionTargetType{
     Message,
     Thread,
     Comment,
-    Reply
+    Reply,
+    ReactionTargetType_MSG = 'ReactionTargetType_MSG'
 }
 


### PR DESCRIPTION
频道消息表态与官方文档表现不一致,文档target.type为0,实际为"ReactionTargetType_MSG"